### PR TITLE
Updated URLs to nzhistory,

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NZ Memorials
 ============
 
-Data derived from Ministry for Culture and Heritage as CC BY-NC http://www.nzhistory.net.nz/culture/the-memorials-register (specifically http://www.nzhistory.net.nz/locations.kml).
+Data derived from Ministry for Culture and Heritage as CC BY-NC https://nzhistory.govt.nz/culture/the-memorials-register (specifically https://nzhistory.govt.nz/locations.kml).
 
 See [ABOUT.md](ABOUT.md) for the rationale driving the project.
 


### PR DESCRIPTION
Nzhistory has recently updated it's URLs to the .govt.nz TLD, removed the www. and now employs SSL for all URL's.
Contact me if you see any issues as it has been a very recent change.